### PR TITLE
Integrate strava-ruby-client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem "turbo-rails"
 gem "stimulus-rails"
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem "jbuilder"
+gem "strava-ruby-client"
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 # gem "bcrypt", "~> 3.1.7"

--- a/config/initializers/strava.rb
+++ b/config/initializers/strava.rb
@@ -1,0 +1,12 @@
+require 'strava/api/client'
+
+module StravaClient
+  def self.build
+    Strava::Api::Client.new(
+      client_id: Rails.application.credentials.strava_client_id,
+      client_secret: Rails.application.credentials.strava_client_secret,
+      access_token: Rails.application.credentials.strava_access_token,
+      refresh_token: Rails.application.credentials.strava_refresh_token
+    )
+  end
+end


### PR DESCRIPTION
## Summary
- add the `strava-ruby-client` gem
- create a `StravaClient` initializer using Rails credentials

## Testing
- `bundle exec rake test` *(fails: ruby-3.3.4 is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6847255b16988333ad34e957d707588d